### PR TITLE
Fix package.json so type-definitions are published

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "files": [
     "src/*",
     "dist/mostDomEvent.js",
-    "type-defintions/dom-event.d.ts"
+    "type-definitions/dom-event.d.ts"
   ],
   "scripts": {
     "build": "npm run build-dist && uglifyjs dist/mostDomEvent.js -o dist/mostDomEvent.min.js",


### PR DESCRIPTION
The current `package.json` contains a typo in the `files` key that is causing type definitions to not be published. I'd think `npm` should complain when something in `files` is missing, but apparently, it is not.

This PR fixes the typo so that type-definitions should be published with the next version.
