### PR TITLE
feat: provide more detailed types for domEvent

### DIFF
--- a/type-definitions/dom-event.d.ts
+++ b/type-definitions/dom-event.d.ts
@@ -1,5 +1,8 @@
-import {Stream} from "@most/types";
+import { Stream } from "@most/types";
 
+export function domEvent<E extends keyof ElementEventMap>(event: E, node: Element, capture?: boolean | AddEventListenerOptions): Stream<ElementEventMap[E]>
+export function domEvent<E extends keyof HTMLElementEventMap>(event: E, node: HTMLElement, capture?: boolean | AddEventListenerOptions): Stream<HTMLElementEventMap[E]>
+export function domEvent<E extends keyof SVGElementEventMap>(event: E, node: SVGElement, capture?: boolean | AddEventListenerOptions): Stream<SVGElementEventMap[E]>
 export function domEvent(event: string, node: EventTarget, capture?: boolean | AddEventListenerOptions): Stream<Event>
 
 export function blur(node: EventTarget, capture?: boolean | AddEventListenerOptions): Stream<FocusEvent>;


### PR DESCRIPTION
Provide `domEvent` with variants for `Element`, `HTMLElement`, and `SVGElement`.

It should provide more useful event types when making use of `domEvent` when you have an `Element`, `HTMLElment`, or `SVGElement` and should still fall through to `event: string` when you’re using a custom event type or if `node` is only statically known to be a valid `EventTarget`