### PR TITLE
feat: narrow down type of currentTarget

### DIFF
--- a/type-definitions/dom-event.d.ts
+++ b/type-definitions/dom-event.d.ts
@@ -1,49 +1,49 @@
 import { Stream } from "@most/types";
 
-export function domEvent<E extends keyof ElementEventMap>(event: E, node: Element, capture?: boolean | AddEventListenerOptions): Stream<ElementEventMap[E]>
-export function domEvent<E extends keyof HTMLElementEventMap>(event: E, node: HTMLElement, capture?: boolean | AddEventListenerOptions): Stream<HTMLElementEventMap[E]>
-export function domEvent<E extends keyof SVGElementEventMap>(event: E, node: SVGElement, capture?: boolean | AddEventListenerOptions): Stream<SVGElementEventMap[E]>
-export function domEvent(event: string, node: EventTarget, capture?: boolean | AddEventListenerOptions): Stream<Event>
+export function domEvent<E extends keyof ElementEventMap, N extends Element = Element>(event: E, node: N, capture?: boolean | AddEventListenerOptions): Stream<ElementEventMap[E] & { currentTarget: N }>
+export function domEvent<E extends keyof HTMLElementEventMap, N extends HTMLElement = HTMLElement>(event: E, node: HTMLElement, capture?: boolean | AddEventListenerOptions): Stream<HTMLElementEventMap[E] & { currentTarget: N }>
+export function domEvent<E extends keyof SVGElementEventMap, N extends SVGElement = SVGElement>(event: E, node: SVGElement, capture?: boolean | AddEventListenerOptions): Stream<SVGElementEventMap[E] & { currentTarget: N }>
+export function domEvent<N extends EventTarget>(event: string, node: N, capture?: boolean | AddEventListenerOptions): Stream<Event & { currentTarget: N }>
 
-export function blur(node: EventTarget, capture?: boolean | AddEventListenerOptions): Stream<FocusEvent>;
-export function focus(node: EventTarget, capture?: boolean | AddEventListenerOptions): Stream<FocusEvent>;
-export function focusin(node: EventTarget, capture?: boolean | AddEventListenerOptions): Stream<FocusEvent>;
-export function focusout(node: EventTarget, capture?: boolean | AddEventListenerOptions): Stream<FocusEvent>;
-export function click(node: EventTarget, capture?: boolean | AddEventListenerOptions): Stream<MouseEvent>;
-export function dblclick(node: EventTarget, capture?: boolean | AddEventListenerOptions): Stream<MouseEvent>;
-export function mousedown(node: EventTarget, capture?: boolean | AddEventListenerOptions): Stream<MouseEvent>;
-export function mouseup(node: EventTarget, capture?: boolean | AddEventListenerOptions): Stream<MouseEvent>;
-export function mousemove(node: EventTarget, capture?: boolean | AddEventListenerOptions): Stream<MouseEvent>;
-export function mouseover(node: EventTarget, capture?: boolean | AddEventListenerOptions): Stream<MouseEvent>;
-export function mouseenter(node: EventTarget, capture?: boolean | AddEventListenerOptions): Stream<MouseEvent>;
-export function mouseout(node: EventTarget, capture?: boolean | AddEventListenerOptions): Stream<MouseEvent>;
-export function mouseleave(node: EventTarget, capture?: boolean | AddEventListenerOptions): Stream<MouseEvent>;
-export function change(node: EventTarget, capture?: boolean | AddEventListenerOptions): Stream<Event>;
-export function select(node: EventTarget, capture?: boolean | AddEventListenerOptions): Stream<UIEvent>;
-export function submit(node: EventTarget, capture?: boolean | AddEventListenerOptions): Stream<Event>;
-export function keydown(node: EventTarget, capture?: boolean | AddEventListenerOptions): Stream<KeyboardEvent>;
-export function keypress(node: EventTarget, capture?: boolean | AddEventListenerOptions): Stream<KeyboardEvent>;
-export function keyup(node: EventTarget, capture?: boolean | AddEventListenerOptions): Stream<KeyboardEvent>;
-export function input(node: EventTarget, capture?: boolean | AddEventListenerOptions): Stream<Event>;
-export function contextmenu(node: EventTarget, capture?: boolean | AddEventListenerOptions): Stream<PointerEvent>;
-export function resize(node: EventTarget, capture?: boolean | AddEventListenerOptions): Stream<UIEvent>;
-export function scroll(node: EventTarget, capture?: boolean | AddEventListenerOptions): Stream<UIEvent>;
-export function error(node: EventTarget, capture?: boolean | AddEventListenerOptions): Stream<ErrorEvent>;
+export function blur<N extends EventTarget>(node: EventTarget, capture?: boolean | AddEventListenerOptions): Stream<FocusEvent & { currentTarget: N }>;
+export function focus<N extends EventTarget>(node: EventTarget, capture?: boolean | AddEventListenerOptions): Stream<FocusEvent & { currentTarget: N }>;
+export function focusin<N extends EventTarget>(node: EventTarget, capture?: boolean | AddEventListenerOptions): Stream<FocusEvent & { currentTarget: N }>;
+export function focusout<N extends EventTarget>(node: EventTarget, capture?: boolean | AddEventListenerOptions): Stream<FocusEvent & { currentTarget: N }>;
+export function click<N extends EventTarget>(node: EventTarget, capture?: boolean | AddEventListenerOptions): Stream<MouseEvent & { currentTarget: N }>;
+export function dblclick<N extends EventTarget>(node: EventTarget, capture?: boolean | AddEventListenerOptions): Stream<MouseEvent & { currentTarget: N }>;
+export function mousedown<N extends EventTarget>(node: EventTarget, capture?: boolean | AddEventListenerOptions): Stream<MouseEvent & { currentTarget: N }>;
+export function mouseup<N extends EventTarget>(node: EventTarget, capture?: boolean | AddEventListenerOptions): Stream<MouseEvent & { currentTarget: N }>;
+export function mousemove<N extends EventTarget>(node: EventTarget, capture?: boolean | AddEventListenerOptions): Stream<MouseEvent & { currentTarget: N }>;
+export function mouseover<N extends EventTarget>(node: EventTarget, capture?: boolean | AddEventListenerOptions): Stream<MouseEvent & { currentTarget: N }>;
+export function mouseenter<N extends EventTarget>(node: EventTarget, capture?: boolean | AddEventListenerOptions): Stream<MouseEvent & { currentTarget: N }>;
+export function mouseout<N extends EventTarget>(node: EventTarget, capture?: boolean | AddEventListenerOptions): Stream<MouseEvent & { currentTarget: N }>;
+export function mouseleave<N extends EventTarget>(node: EventTarget, capture?: boolean | AddEventListenerOptions): Stream<MouseEvent & { currentTarget: N }>;
+export function change<N extends EventTarget>(node: EventTarget, capture?: boolean | AddEventListenerOptions): Stream<Event & { currentTarget: N }>;
+export function select<N extends EventTarget>(node: EventTarget, capture?: boolean | AddEventListenerOptions): Stream<UIEvent & { currentTarget: N }>;
+export function submit<N extends EventTarget>(node: EventTarget, capture?: boolean | AddEventListenerOptions): Stream<Event & { currentTarget: N }>;
+export function keydown<N extends EventTarget>(node: EventTarget, capture?: boolean | AddEventListenerOptions): Stream<KeyboardEvent & { currentTarget: N }>;
+export function keypress<N extends EventTarget>(node: EventTarget, capture?: boolean | AddEventListenerOptions): Stream<KeyboardEvent & { currentTarget: N }>;
+export function keyup<N extends EventTarget>(node: EventTarget, capture?: boolean | AddEventListenerOptions): Stream<KeyboardEvent & { currentTarget: N }>;
+export function input<N extends EventTarget>(node: EventTarget, capture?: boolean | AddEventListenerOptions): Stream<Event & { currentTarget: N }>;
+export function contextmenu<N extends EventTarget>(node: EventTarget, capture?: boolean | AddEventListenerOptions): Stream<PointerEvent & { currentTarget: N }>;
+export function resize<N extends EventTarget>(node: EventTarget, capture?: boolean | AddEventListenerOptions): Stream<UIEvent & { currentTarget: N }>;
+export function scroll<N extends EventTarget>(node: EventTarget, capture?: boolean | AddEventListenerOptions): Stream<UIEvent & { currentTarget: N }>;
+export function error<N extends EventTarget>(node: EventTarget, capture?: boolean | AddEventListenerOptions): Stream<ErrorEvent & { currentTarget: N }>;
 
-export function hashchange(node: EventTarget, capture?: boolean | AddEventListenerOptions): Stream<HashChangeEvent>;
-export function popstate(node: EventTarget, capture?: boolean | AddEventListenerOptions): Stream<PopStateEvent>;
-export function load(node: EventTarget, capture?: boolean | AddEventListenerOptions): Stream<Event>;
-export function unload(node: EventTarget, capture?: boolean | AddEventListenerOptions): Stream<Event>;
+export function hashchange<N extends Window>(node: N, capture?: boolean | AddEventListenerOptions): Stream<HashChangeEvent & { currentTarget: N }>;
+export function popstate<N extends Window>(node: N, capture?: boolean | AddEventListenerOptions): Stream<PopStateEvent & { currentTarget: N }>;
+export function load<N extends Window>(node: N, capture?: boolean | AddEventListenerOptions): Stream<Event & { currentTarget: N }>;
+export function unload<N extends Window>(node: N, capture?: boolean | AddEventListenerOptions): Stream<Event & { currentTarget: N }>;
 
-export function pointerdown(node: EventTarget, capture?: boolean | AddEventListenerOptions): Stream<Event>;
-export function pointerup(node: EventTarget, capture?: boolean | AddEventListenerOptions): Stream<Event>;
-export function pointermove(node: EventTarget, capture?: boolean | AddEventListenerOptions): Stream<Event>;
-export function pointerover(node: EventTarget, capture?: boolean | AddEventListenerOptions): Stream<Event>;
-export function pointerenter(node: EventTarget, capture?: boolean | AddEventListenerOptions): Stream<Event>;
-export function pointerout(node: EventTarget, capture?: boolean | AddEventListenerOptions): Stream<Event>;
-export function pointerleave(node: EventTarget, capture?: boolean | AddEventListenerOptions): Stream<Event>;
+export function pointerdown<N extends HTMLElement>(node: N, capture?: boolean | AddEventListenerOptions): Stream<Event & { currentTarget: N }>;
+export function pointerup<N extends HTMLElement>(node: N, capture?: boolean | AddEventListenerOptions): Stream<Event & { currentTarget: N }>;
+export function pointermove<N extends HTMLElement>(node: N, capture?: boolean | AddEventListenerOptions): Stream<Event & { currentTarget: N }>;
+export function pointerover<N extends HTMLElement>(node: N, capture?: boolean | AddEventListenerOptions): Stream<Event & { currentTarget: N }>;
+export function pointerenter<N extends HTMLElement>(node: N, capture?: boolean | AddEventListenerOptions): Stream<Event & { currentTarget: N }>;
+export function pointerout<N extends HTMLElement>(node: N, capture?: boolean | AddEventListenerOptions): Stream<Event & { currentTarget: N }>;
+export function pointerleave<N extends HTMLElement>(node: N, capture?: boolean | AddEventListenerOptions): Stream<Event & { currentTarget: N }>;
 
-export function touchstart(node: EventTarget, capture?: boolean | AddEventListenerOptions): Stream<TouchEvent>;
-export function touchend(node: EventTarget, capture?: boolean | AddEventListenerOptions): Stream<TouchEvent>;
-export function touchmove(node: EventTarget, capture?: boolean | AddEventListenerOptions): Stream<TouchEvent>;
-export function touchcancel(node: EventTarget, capture?: boolean | AddEventListenerOptions): Stream<TouchEvent>;
+export function touchstart<N extends HTMLElement>(node: N, capture?: boolean | AddEventListenerOptions): Stream<TouchEvent & { currentTarget: N }>;
+export function touchend<N extends HTMLElement>(node: N, capture?: boolean | AddEventListenerOptions): Stream<TouchEvent & { currentTarget: N }>;
+export function touchmove<N extends HTMLElement>(node: N, capture?: boolean | AddEventListenerOptions): Stream<TouchEvent & { currentTarget: N }>;
+export function touchcancel<N extends HTMLElement>(node: N, capture?: boolean | AddEventListenerOptions): Stream<TouchEvent & { currentTarget: N }>;


### PR DESCRIPTION
This PR tries to narrow down the type of `currentTarget` when the node type is statically known. I think that line 33 and down may be a breaking change because it makes the type of `node` no longer support all `EventTarget`s but looking on MDN these are the places that implement these events. If it's preferred I can put that change into a separate PR to just get the `currentTarget` changes merged before.